### PR TITLE
Add the legacy mode NS flag to the gazebo file

### DIFF
--- a/moose_description/urdf/moose.gazebo
+++ b/moose_description/urdf/moose.gazebo
@@ -3,6 +3,7 @@
   <gazebo>
     <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
       <robotNamespace>/</robotNamespace>
+      <legacyModeNS>true</legacyModeNS>
     </plugin>
   </gazebo>
 


### PR DESCRIPTION
This gets rid of a warning when launching gazebo.  Similar change is already made in Warthog, but I don't have permission to write to the moose repo.