### PR TITLE
Improve game controller support

### DIFF
--- a/moose_control/config/teleop.yaml
+++ b/moose_control/config/teleop.yaml
@@ -5,8 +5,8 @@ joy_teleop:
     scale_linear_turbo: 1.0
     axis_angular: 0
     scale_angular: 2.4
-    enable_button: 0
-    enable_turbo_button: 2
+    enable_button: 4
+    enable_turbo_button: 5
   joy_node:
     deadzone: 0.1
     autorepeat_rate: 20

--- a/moose_control/config/twist_mux_rc.yaml
+++ b/moose_control/config/twist_mux_rc.yaml
@@ -3,6 +3,10 @@ topics:
   topic   : twist_marker_server/cmd_vel
   timeout : 0.5
   priority: 6
+- name    : joy
+  topic   : joy_teleop/cmd_vel
+  timeout : 0.5
+  priority: 8
 - name    : rc
   topic   : rc_teleop/cmd_vel
   timeout : 0.5

--- a/moose_control/launch/teleop.launch
+++ b/moose_control/launch/teleop.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <launch>
 
-  <arg name="joy_dev" default="/dev/input/js0" />
-  <arg name="joy_teleop" default="true" />
+  <arg name="joy_dev" default="$(optenv MOOSE_JOY_DEV /dev/input/js0)" />
+  <arg name="joy_teleop" default="$(optenv MOOSE_JOY_TELEOP false)" />
 
-  <group ns="joy_teleop" if="$(optenv MOOSE_JOY_TELEOP 0)">
+  <group ns="joy_teleop" if="$(arg joy_teleop)">
     <rosparam command="load" file="$(find moose_control)/config/teleop.yaml" />
     <node pkg="joy" type="joy_node" name="joy_node">
       <param name="dev" value="$(arg joy_dev)" />


### PR DESCRIPTION
Moose had code to allow bluetooth/other game controller input, but the messages were never subscribed to by twist_mux.

This enables game controllers to be used to drive the robot properly inside Gazebo simulations and keeps things consistent with recent changes to Warthog.