### PR TITLE
Move rosparam load outside the joy_teleop ns.

### DIFF
--- a/moose_control/config/teleop.yaml
+++ b/moose_control/config/teleop.yaml
@@ -1,12 +1,11 @@
-joy_teleop:
-  teleop_twist_joy:
-    axis_linear: 1
-    scale_linear: 0.5
-    scale_linear_turbo: 1.0
-    axis_angular: 0
-    scale_angular: 2.4
-    enable_button: 4
-    enable_turbo_button: 5
-  joy_node:
-    deadzone: 0.1
-    autorepeat_rate: 20
+teleop_twist_joy:
+  axis_linear: 1
+  scale_linear: 0.5
+  scale_linear_turbo: 1.0
+  axis_angular: 0
+  scale_angular: 2.4
+  enable_button: 4
+  enable_turbo_button: 5
+joy_node:
+  deadzone: 0.1
+  autorepeat_rate: 20

--- a/moose_control/launch/teleop.launch
+++ b/moose_control/launch/teleop.launch
@@ -4,8 +4,8 @@
   <arg name="joy_dev" default="$(optenv MOOSE_JOY_DEV /dev/input/js0)" />
   <arg name="joy_teleop" default="$(optenv MOOSE_JOY_TELEOP false)" />
 
+  <rosparam command="load" file="$(find moose_control)/config/teleop.yaml" />
   <group ns="joy_teleop" if="$(arg joy_teleop)">
-    <rosparam command="load" file="$(find moose_control)/config/teleop.yaml" />
     <node pkg="joy" type="joy_node" name="joy_node">
       <param name="dev" value="$(arg joy_dev)" />
     </node>

--- a/moose_control/launch/teleop.launch
+++ b/moose_control/launch/teleop.launch
@@ -4,8 +4,8 @@
   <arg name="joy_dev" default="$(optenv MOOSE_JOY_DEV /dev/input/js0)" />
   <arg name="joy_teleop" default="$(optenv MOOSE_JOY_TELEOP false)" />
 
-  <rosparam command="load" file="$(find moose_control)/config/teleop.yaml" />
   <group ns="joy_teleop" if="$(arg joy_teleop)">
+    <rosparam command="load" file="$(find moose_control)/config/teleop.yaml" />
     <node pkg="joy" type="joy_node" name="joy_node">
       <param name="dev" value="$(arg joy_dev)" />
     </node>


### PR DESCRIPTION
Move the joy parameters outside the joy_teleop ns to avoid duplicating the namespace. Resolves https://github.com/moose-cpr/moose/issues/4